### PR TITLE
Configure automatic release upon upstream tag

### DIFF
--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Create Release 
         if: ${{ !contains('-RC', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         run: | 
-          echo "Creating release ${{ join(['v',fromJSON(steps.latest_tag.outputs.tags)[0]], '') }}"
+          echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
         

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -26,7 +26,7 @@ jobs:
           # The name of the repository. Used to identify the repository on which to release.
           repo: guacamole-client
           # Should get latest release?
-          latest: true
+          latest: false
           # Show ouputs
           debug: true
           # Fail when no release was found

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -50,24 +50,21 @@ jobs:
       
       # Checkout the code for a commit
       #- name: Checkout
-      #  if: ${{ success() }}
+      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: actions/checkout@v2
         
       # Create a commit for this release
       #- name: Commit
       #  id: commit
-      #  if: ${{ success() }}
+      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: zwaldowski/git-commit-action@v1
       #  with:
       #    commit_message: Bumping version to ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       
       # Create a new release for the Guacamole tag
       - name: Create Release
-        if: ${{ success() }}
-        #run: | 
-        #  echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
+        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         uses: ncipollo/release-action@v1.10.0
         with:
           tag: ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
-          #commit: ${{ steps.commit.outputs.sha }}
           commit: main

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -44,26 +44,26 @@ jobs:
       # If the latest Guacamole tag doesn't match our latest release,
       - name: Compare Versions
         id: compare_versions
-        if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         run: |
           echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
       
       # Checkout the code for a commit
       #- name: Checkout
-      #  if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: actions/checkout@v2
         
       # Create a commit for this release
       #- name: Commit
       #  id: commit
-      #  if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: zwaldowski/git-commit-action@v1
       #  with:
       #    commit_message: Bumping version to ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       
       # Create a new release for the Guacamole tag
       - name: Create Release
-        if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         uses: ncipollo/release-action@v1.10.0
         with:
           tag: ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -7,23 +7,21 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   get-latest-release:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Get the latest Guacamole Docker tag
       - name: Get Docker Hub Tag
-        # You may pin to the exact commit or the version.
-        # uses: jacobtomlinson/gha-get-docker-hub-tags@4d1339c986f06d2b6ffc2ef0fff024dca0ef0735
         uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
         with:
           # The Docker Hub org
-          org: guacamole
+          org: 'guacamole'
           # The Docker Hub repo
-          repo: guacamole
-        #env:
-        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo: 'guacamole'
+          
+      # Use the tag we got back
+      - name: Check outputs
+        run: |
+          echo "Latest Image Tag - ${{ steps.latest_tag.outputs.tag }}"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -23,7 +23,7 @@ jobs:
       
       - name: Get Latest Tag
         id: latest_tag
-        uses: oraad/get-tags-action@v1
+        uses: oraad/get-tags-action@v1.0.0
         with:
           repo: apache/guacamole-client
           limit: 1

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -21,10 +21,10 @@ jobs:
           repo: apache/guacamole-client
           limit: 1
       
-      # Check the tag we got back
+      # Check the Guacamole tag we got back
       - name: Check Output
         run: |
-          echo "Latest Tag - ${{ steps.latest_tag.outputs.tags }}"
+          echo "Latest Guacamole - ${{ steps.latest_tag.outputs.tags[0] }}"
       
       # Get our latest release
       # Format: 'vMajor.minor.rev'
@@ -33,11 +33,16 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@v0.5.0
         with:
           repository: ${{ github.repository }}
-      
+          
+      # Check the local release we got back
+      - name: Check Output
+        run: |
+          echo "Latest Local - ${{ steps.latest_reelase.outputs.release }}"
+          
       # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
       # Create a new release for the Guacamole tag
       - name: Create Release 
-        if: ${{ steps.latest_release.outputs.release }} != ${{ steps.latest_tag.outputs.tags }}
+        if: ${{ steps.latest_release.outputs.release }} != "v${{ steps.latest_tag.outputs.tags[0] }}"
         run: | 
-          echo "Creating release v${{ steps.latest_tag.outputs.tags }}"
+          echo "Creating release v${{ steps.latest_tag.outputs.tags[0] }}"
         

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -16,20 +16,14 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Get Release
+      - name: Get Docker Hub Tag
         # You may pin to the exact commit or the version.
-        # uses: joutvhu/get-release@892bd55b92fd5a79f97836964d6abc7b81bb1bdd
-        uses: joutvhu/get-release@v1.0.1
+        # uses: jacobtomlinson/gha-get-docker-hub-tags@4d1339c986f06d2b6ffc2ef0fff024dca0ef0735
+        uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
         with:
-          # The name of the owner of the repo. Used to identify the owner of the repository.
-          owner: apache
-          # The name of the repository. Used to identify the repository on which to release.
-          repo: guacamole-client
-          # Should get latest release?
-          latest: false
-          # Show ouputs
-          debug: true
-          # Fail when no release was found
-          throwing: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The Docker Hub org
+          org: guacamole
+          # The Docker Hub repo
+          repo: guacamole
+        #env:
+        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -24,7 +24,7 @@ jobs:
       # Check the Guacamole tag we got back
       - name: Check Output
         run: |
-          echo "Latest Guacamole - ${{ steps.latest_tag.outputs.tags[0] }}"
+          echo "Latest Guacamole - ${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
       
       # Get our latest release
       # Format: 'vMajor.minor.rev'
@@ -37,12 +37,12 @@ jobs:
       # Check the local release we got back
       - name: Check Output
         run: |
-          echo "Latest Local - ${{ steps.latest_reelase.outputs.release }}"
+          echo "Latest Local - ${{ steps.latest_release.outputs.release }}"
           
       # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
       # Create a new release for the Guacamole tag
       - name: Create Release 
-        if: ${{ steps.latest_release.outputs.release }} != "v${{ steps.latest_tag.outputs.tags[0] }}"
+        if: ${{ steps.latest_release.outputs.release }} != "v${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
         run: | 
-          echo "Creating release v${{ steps.latest_tag.outputs.tags[0] }}"
+          echo "Creating release v${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
         

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -13,15 +13,22 @@ jobs:
 
     steps:
       # Get the latest Guacamole Docker tag
-      - name: Get Docker Hub Tag
-        uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
+      #- name: Get Docker Hub Tag
+      #  uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
+      #  with:
+      #    # The Docker Hub org
+      #    org: 'guacamole'
+      #    # The Docker Hub repo
+      #    repo: 'guacamole'
+      
+      - name: Get Latest Tag
+        id: latest_tag
+        uses: oraad/get-tags-action@v1
         with:
-          # The Docker Hub org
-          org: 'guacamole'
-          # The Docker Hub repo
-          repo: 'guacamole'
-          
+          repo: apache/guacamole-client
+          limit: 1
+      
       # Use the tag we got back
       - name: Check outputs
         run: |
-          echo "Latest Image Tag - ${{ steps.latest_tag.outputs.tag }}"
+          echo "Latest Tag - ${{ steps.latest_tag.outputs.tags }}"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -63,7 +63,7 @@ jobs:
       
       # Create a new release for the Guacamole tag
       - name: Create Release
-        if: ${{ sucess() }}
+        if: ${{ success() }}
         #run: | 
         #  echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
         uses: ncipollo/release-action@v1.10.0

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -42,7 +42,7 @@ jobs:
       # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
       # Create a new release for the Guacamole tag
       - name: Create Release 
-        if: ${{ steps.latest_release.outputs.release }} != "v${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
+        if: ${{ steps.latest_release.outputs.release != 'v' + fromJSON(steps.latest_tag.outputs.tags)[0] }}
         run: | 
           echo "Creating release v${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
         

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -41,29 +41,29 @@ jobs:
         run: |
           echo "Latest Local - ${{ steps.latest_release.outputs.release }}"
           
-      # If the latest Guacamole tag doesn't match our latest release, and also doesn't contain a dash (-),
+      # If the latest Guacamole tag doesn't match our latest release,
       - name: Compare Versions
         id: compare_versions
-        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+        if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         run: |
           echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
       
       # Checkout the code for a commit
       #- name: Checkout
-      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+      #  if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: actions/checkout@v2
         
       # Create a commit for this release
       #- name: Commit
       #  id: commit
-      #  if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+      #  if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       #  uses: zwaldowski/git-commit-action@v1
       #  with:
       #    commit_message: Bumping version to ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
       
       # Create a new release for the Guacamole tag
       - name: Create Release
-        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+        if: ${{ !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         uses: ncipollo/release-action@v1.10.0
         with:
           tag: ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -1,4 +1,4 @@
-# This is a basic workflow to help you get started with Actions
+# Checks for new upstream releases and creates matching local releases
 
 name: Check Upstream Release
 
@@ -12,23 +12,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Get the latest Guacamole Docker tag
-      #- name: Get Docker Hub Tag
-      #  uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
-      #  with:
-      #    # The Docker Hub org
-      #    org: 'guacamole'
-      #    # The Docker Hub repo
-      #    repo: 'guacamole'
-      
-      - name: Get Latest Tag
+      # Get the latest Guacamole tag
+      # Format: 'Major.minor.rev(-RCcandidate)?'
+      - name: Get Latest Guacamole Tag
         id: latest_tag
         uses: oraad/get-tags-action@v1.0.0
         with:
           repo: apache/guacamole-client
           limit: 1
       
-      # Use the tag we got back
-      - name: Check outputs
+      # Check the tag we got back
+      - name: Check Output
         run: |
           echo "Latest Tag - ${{ steps.latest_tag.outputs.tags }}"
+      
+      # Get our latest release
+      # Format: 'vMajor.minor.rev'
+      - name: Get Latest Local Release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@v0.5.0
+        with:
+          repository: ${{ github.repository }}
+      
+      # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
+      # Create a new release for the Guacamole tag
+      - name: Create Release 
+        if: ${{ steps.latest_release.outputs.release }} != ${{ steps.latest_tag.outputs.tags }}
+        run: | 
+          echo "Creating release v${{ steps.latest_tag.outputs.tags }}"
+        

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   get-latest-release:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      
     steps:
       # Get the latest Guacamole tag
       # Format: 'Major.minor.rev(-RCcandidate)?'
@@ -39,10 +41,33 @@ jobs:
         run: |
           echo "Latest Local - ${{ steps.latest_release.outputs.release }}"
           
-      # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
-      # Create a new release for the Guacamole tag
-      - name: Create Release 
-        if: ${{ !contains('-RC', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
-        run: | 
+      # If the latest Guacamole tag doesn't match our latest release, and also doesn't contain a dash (-),
+      - name: Compare Versions
+        id: compare_versions
+        if: ${{ !contains('-', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+        run: |
           echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
+      
+      # Checkout the code for a commit
+      #- name: Checkout
+      #  if: ${{ success() }}
+      #  uses: actions/checkout@v2
         
+      # Create a commit for this release
+      #- name: Commit
+      #  id: commit
+      #  if: ${{ success() }}
+      #  uses: zwaldowski/git-commit-action@v1
+      #  with:
+      #    commit_message: Bumping version to ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+      
+      # Create a new release for the Guacamole tag
+      - name: Create Release
+        if: ${{ sucess() }}
+        #run: | 
+        #  echo "Creating release ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}"
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          tag: ${{ format('v{0}',fromJSON(steps.latest_tag.outputs.tags)[0]) }}
+          #commit: ${{ steps.commit.outputs.sha }}
+          commit: main

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -42,7 +42,7 @@ jobs:
       # If the latest Guacamole tag doesn't match our latest release, and also doesn't end in '-RCx',
       # Create a new release for the Guacamole tag
       - name: Create Release 
-        if: ${{ steps.latest_release.outputs.release != 'v' + fromJSON(steps.latest_tag.outputs.tags)[0] }}
+        if: ${{ !contains('-RC', fromJSON(steps.latest_tag.outputs.tags)[0]) && !endsWith(steps.latest_release.outputs.release, fromJSON(steps.latest_tag.outputs.tags)[0]) }}
         run: | 
-          echo "Creating release v${{ fromJSON(steps.latest_tag.outputs.tags)[0] }}"
+          echo "Creating release ${{ join(['v',fromJSON(steps.latest_tag.outputs.tags)[0]], '') }}"
         

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: ci
+name: docker-build
 
 on:
   pull_request:
@@ -22,8 +22,10 @@ jobs:
           DOCKER_IMAGE=portableprogrammer/guacamole
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8
           VERSION=edge
+          GUACAMOLE_VERSION=1.0.0
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
+            GUACAMOLE_VERSION=${GITHUB_REF#refs/tags/v#v}
           fi
           
           TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
@@ -34,6 +36,7 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
             --build-arg VERSION=${VERSION} \
+            --build-arg GUACAMOLE_VERSION=${GUACAMOLE_VERSION} \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} --file ./Dockerfile ./

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,6 @@
 name: docker-build
 
 on:
-  pull_request:
-    branches: main
   push:
     branches: main
     tags:
@@ -22,21 +20,21 @@ jobs:
           DOCKER_IMAGE=portableprogrammer/guacamole
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8
           VERSION=edge
-          GUACAMOLE_VERSION=1.0.0
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
-            GUACAMOLE_VERSION=${GITHUB_REF#refs/tags/v#v}
           fi
           
           TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}(\.[0-9]{1,3})?$ ]]; then
             TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          else
+            TAGS="$TAGS --tag ${DOCKER_IMAGE}:edge"
           fi
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
             --build-arg VERSION=${VERSION} \
-            --build-arg GUACAMOLE_VERSION=${GUACAMOLE_VERSION} \
+            --build-arg GUACAMOLE_VERSION=${VERSION} \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} --file ./Dockerfile ./


### PR DESCRIPTION
The upstream, [apache/guacamole-client](https://github.com/apache/guacamole-client), doesn't utilize release tags, and has an agonizingly slow release schedule (~6 mo, it seems). To keep this repo up to date, find the latest tag in the upstream repo, then commit a new, matching release tag here to trigger a new build.

The upstream repo has two main types of tags: full release (e.g. `1.4.0`) and release candidates (e.g. `1.4.0-RC1`).  Only full releases get prebuilt `WARs`, so we'll ignore any `-RCx` tags.